### PR TITLE
Updated Swedish translations (#571) (patch)

### DIFF
--- a/src/assets/translations/sv.json
+++ b/src/assets/translations/sv.json
@@ -1,30 +1,30 @@
 {
   "tooltips": {
-    "placeMarker": "Klicka för att placera punkt",
-    "firstVertex": "Klicka för att placera första vertex",
+    "placeMarker": "Klicka för att placera markör",
+    "firstVertex": "Klicka för att placera första hörnet",
     "continueLine": "Klicka för att fortsätta rita",
     "finishLine": "Klicka på en existerande punkt för att slutföra",
     "finishPoly": "Klicka på den första punkten för att slutföra",
     "finishRect": "Klicka för att slutföra",
     "startCircle": "Klicka för att placera cirkelns centrum",
     "finishCircle": "Klicka för att slutföra cirkeln",
-    "placeCircleMarker": "Klicka för att placera cirkelmakör"
+    "placeCircleMarker": "Klicka för att placera cirkelmarkör"
   },
   "actions": {
     "finish": "Slutför",
     "cancel": "Avbryt",
-    "removeLastVertex": "Ta bort sista vertex"
+    "removeLastVertex": "Ta bort sista hörnet"
   },
   "buttonTitles": {
-    "drawMarkerButton": "Rita Punkt",
-    "drawPolyButton": "Rita Rolygoner",
-    "drawLineButton": "Rita Polyline",
-    "drawCircleButton": "Rta Cirkel",
-    "drawRectButton": "Rita Rectangle",
+    "drawMarkerButton": "Rita Markör",
+    "drawPolyButton": "Rita Polygoner",
+    "drawLineButton": "Rita Linje",
+    "drawCircleButton": "Rita Cirkel",
+    "drawRectButton": "Rita Rektangel",
     "editButton": "Redigera Lager",
     "dragButton": "Dra Lager",
     "cutButton": "Klipp i Lager",
     "deleteButton": "Ta bort Lager",
-    "drawCircleMarkerButton": "Rita Cirkelmakör"
+    "drawCircleMarkerButton": "Rita Cirkelmarkör"
   }
 }


### PR DESCRIPTION
* Swedish translation: Correction of some misspellings

* Swedish translation: Some more translations of english words into swedish
(and *if* the word "Polylinje" exists at all in swedish then it should be spelled including a "j")

* Swedish translation: Translated "marker" ==> "markör" (similar to the existing translation of "circle marker" ==> "cirkelmarkör")

* Swedish translation: Replaced the word "Polylinje" with "Linje".
It is questionable whether the word "Polylinje" exists at all but it is at least not a word that the average swedish end-user would be familiar with.
No search result for the word "polylinje":
https://svenska.se/tre/?sok=polylinje&pz=1
https://tyda.se/search/polylinje?lang%5B0%5D=en&lang%5B1%5D=sv